### PR TITLE
Update dependency(ecstatic)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "concat-stream": "^1.4.6",
     "deepcopy": "^0.4.0",
     "director": "^1.2.3",
-    "ecstatic": "^0.5.4",
+    "ecstatic": "^3.3.0",
     "minilog": "^2.0.6",
     "serve-favicon": "^2.1.6",
     "swig": "^1.4.2",


### PR DESCRIPTION
Hello, I tried http://edu.biojs.net/101/bootstrapping/ on OS X El Capitan and Node v11.1.0, but when I access to http://localhost:9090/ after running sniper on working directory, it fails as follows.

```
TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["etag"]
    at ServerResponse.setHeader (_http_outgoing.js:473:3)
    at module.exports.ResponseStream.(anonymous function) [as setHeader] (~/node_modules/union/lib/response-stream.js:100:34)
    at ~/node_modules/ecstatic/lib/ecstatic/showdir.js:42:13
    at FSReqCallback.oncomplete (fs.js:148:20)
```

I found this error does not occur after I updated the dependency of ecstatic, probably because this error is caused on serving current directory as a file server using ecstatic.